### PR TITLE
Bruteforce permissions for indexing on Terra

### DIFF
--- a/vcf_view.wdl
+++ b/vcf_view.wdl
@@ -48,6 +48,10 @@ task xVCFView {
         preemptible: "${preemptible}"
     }
     command <<<
+        # do not delete these lines -- they are required for indexing to work properly on Terra
+        set -eux -o pipefail
+        find . -type d -exec sudo chmod -R 777 {} +
+
         echo "input vcf: '~{input_vcf}'"
         echo "input vcf index: '~{input_vcf_index}'"
 


### PR DESCRIPTION
Terra sets every file in the /inputs/ directory as read-only, as well as the directory itself. This means workflows that either
* modify an input file directly
* drop a file into the input directory
end up with some problems that won't show up on local runs. In this case, the indexing step will fail because the index cannot be written into the input directory.

I expected the next part to not work, as I figured it may not be able to find the index in the inputs directory, but it seems to be working on Terra now. Tested via gs version of regions_and_samples.json (see other PR).