### PR TITLE
Add disk runtime attribute

### DIFF
--- a/vcf_view.wdl
+++ b/vcf_view.wdl
@@ -12,7 +12,7 @@ workflow xVCFViewWorkflow {
         Int cpu = 8
         Int memory = 64
         Int preemptible = 0
-        Int addl_disk = 1
+        Int additional_disk = 1
     }
     call xVCFView { input: input_vcf=input_vcf,
                     input_vcf_index=input_vcf_index,
@@ -41,14 +41,14 @@ task xVCFView {
         Int cpu = 8
         Int memory = 64
         Int preemptible = 0
-        Int addl_disk = 1
+        Int additional_disk = 1
     }
     # estimate disk size required
     Int vcf_size        = ceil(size(input_vcf, "GB"))
     Int index_size      = select_first([ceil(size(input_vcf_index, "GB")), 0])
     Int samples_size    = select_first([ceil(size(samples, "GB")), 0])
     Int regions_size    = select_first([ceil(size(regions, "GB")), 0])
-    Int final_disk_size = vcf_size + index_size + samples_size + regions_size + addl_disk
+    Int final_disk_size = vcf_size + index_size + samples_size + regions_size + additional_disk
     runtime {
         disks: "local-disk " + final_disk_size + " HDD"
         docker: "xbrianh/xsamtools:v0.5.2"

--- a/vcf_view.wdl
+++ b/vcf_view.wdl
@@ -12,6 +12,7 @@ workflow xVCFViewWorkflow {
         Int cpu = 8
         Int memory = 64
         Int preemptible = 0
+        Int addl_disk = 1
     }
     call xVCFView { input: input_vcf=input_vcf,
                     input_vcf_index=input_vcf_index,
@@ -40,8 +41,16 @@ task xVCFView {
         Int cpu = 8
         Int memory = 64
         Int preemptible = 0
+        Int addl_disk = 1
     }
+    # estimate disk size required
+    Int vcf_size        = ceil(size(input_vcf, "GB"))
+    Int index_size      = select_first([ceil(size(input_vcf_index, "GB")), 0])
+    Int samples_size    = select_first([ceil(size(samples, "GB")), 0])
+    Int regions_size    = select_first([ceil(size(regions, "GB")), 0])
+    Int final_disk_size = vcf_size + index_size + samples_size + regions_size + addl_disk
     runtime {
+        disks: "local-disk " + final_disk_size + " HDD"
         docker: "xbrianh/xsamtools:v0.5.2"
         memory: "${memory}G"
         cpu: "${cpu}"


### PR DESCRIPTION
Addresses https://github.com/DataBiosphere/xvcfview/issues/5

Unlike AWS backends which can autoscale at runtime, when using Google to run your WDLs, you basically have to ask Google "hey can I get uhhh 20 GB of storage on a HDD please" before runtime. In WDL this is done via the `disks` runtime attribute. One side effect of this process is that you need to know how big all of your files are going to be ahead of time so you can ask Google for a large enough disk. Luckily, WDL can ***usually*** tell how big files will be before actually localizing them using the size() built-in.

When the runtime attribute for disk size is not set and the WDL is run on Terra, then Terra will default to asking Google for 10 GB. That's fine for some use cases, but not enough for big files.

The way that I like to address this:
1. Explicitly include a `disks` runtime attribute
2. Make the actual size in the `disks` runtime attribute a variable (final_disk_size)
3. Set final_disk_size to be the sum of (size of every required input) + (sum of the size of every (optional input || 0)) + (user-specified extra to tack on via an optional input variable || 1), all units in GB.

Allowing the user to tack on a few extra GB via an optional input variable is good practice, as truly massive inputs can generate large intermediate files that I'm not aware of. It allows them to essentially override the disk size calculation with some huge number if my estimate of input sizes is woefully inadequate, without actually editing the WDL.

You will notice that I do the calculation of final_disk_size in seemingly the middle of nowhere. It is not within the input block, nor the command block. This is, as far as I'm aware, the only way to make a private variable that is calculated before runtime. 